### PR TITLE
Added timeout setting per plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Each `[[plan]]` lists:
  * `code =` For http/https, the expected status code, default 200.
  * `string =` For http/https, a string we expect to find in the result.
  * `regex =` For http/https, a regular expression we expect to match in the result.
+ * `timeout =` An optional timeout for the test in seconds. Default is 3 seconds.
 
 The test plan is run once for each item in the ips list, or more if macros
 are in effect.

--- a/httpunit.go
+++ b/httpunit.go
@@ -428,7 +428,6 @@ func (c *TestCase) testConnect() (r *TestResult) {
 	defer func() {
 		r.TimeTotal = time.Now().Sub(t)
 	}()
-	log.Printf("%v", c.Timeout)
 	conn, err := net.DialTimeout(c.URL.Scheme, c.addr(), c.Timeout)
 	if err != nil {
 		r.Result = err
@@ -446,8 +445,7 @@ func (c *TestCase) testHTTP() (r *TestResult) {
 		r.TimeTotal = time.Now().Sub(t)
 	}()
 	tr := &http.Transport{
-		Dial: func(network, a string) (net.Conn, error) {
-			log.Printf("%v", c.Timeout)
+		Dial: func(network, a string) (net.Conn, error) {)
 			conn, err := net.DialTimeout(network, c.addr(), c.Timeout)
 			if err != nil {
 				r.Connected = false

--- a/httpunit.go
+++ b/httpunit.go
@@ -237,9 +237,10 @@ type TestPlan struct {
 	URL   string
 	IPs   []string
 
-	Code  int
-	Text  string
-	Regex string
+	Code    int
+	Text    string
+	Regex   string
+	Timeout time.Duration
 }
 
 // Cases computes the actual test cases from a test plan. filter and no10 are described in Plans.Test.
@@ -321,9 +322,13 @@ func (p *TestPlan) Cases(filter string, no10 bool, IPs IPMap) ([]*TestCase, erro
 				ExpectCode:  code,
 				ExpectText:  p.Text,
 				ExpectRegex: re,
+				Timeout:     p.Timeout * time.Second,
 			}
 			if c.IP == nil {
 				return fmt.Errorf("invalid ip: %v", ip)
+			}
+			if c.Timeout == 0 {
+				c.Timeout = Timeout
 			}
 			cases = append(cases, c)
 		}
@@ -382,6 +387,8 @@ type TestCase struct {
 	ExpectCode  int
 	ExpectText  string
 	ExpectRegex *regexp.Regexp
+	
+	Timeout time.Duration
 }
 
 type TestResult struct {
@@ -421,7 +428,8 @@ func (c *TestCase) testConnect() (r *TestResult) {
 	defer func() {
 		r.TimeTotal = time.Now().Sub(t)
 	}()
-	conn, err := net.DialTimeout(c.URL.Scheme, c.addr(), Timeout)
+	log.Printf("%v", c.Timeout)
+	conn, err := net.DialTimeout(c.URL.Scheme, c.addr(), c.Timeout)
 	if err != nil {
 		r.Result = err
 		return
@@ -439,7 +447,8 @@ func (c *TestCase) testHTTP() (r *TestResult) {
 	}()
 	tr := &http.Transport{
 		Dial: func(network, a string) (net.Conn, error) {
-			conn, err := net.DialTimeout(network, c.addr(), Timeout)
+			log.Printf("%v", c.Timeout)
+			conn, err := net.DialTimeout(network, c.addr(), c.Timeout)
 			if err != nil {
 				r.Connected = false
 			}
@@ -453,7 +462,7 @@ func (c *TestCase) testHTTP() (r *TestResult) {
 		return
 	}
 	timedOut := false
-	timout := time.AfterFunc(Timeout, func() {
+	timout := time.AfterFunc(c.Timeout, func() {
 		timedOut = true
 		r.Connected = false
 		tr.CancelRequest(req)


### PR DESCRIPTION
This PR adds and optional timeout configuration option per plan. The timeout parameter is in seconds.

If a timeout is not specified, it will use the default of 3 seconds.