### PR TITLE
Issue #9 - add tagging to test plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The flags are:
 		no RFC1918 addresses
 	-timeout="3s"
 		connection timeout
+	-tags=""
+	    if specified, only runs plans that are tagged with one of the
+		tags specified
 	-header="X-Request-Guid"
 		in more verbose mode, print this HTTP header
 	-v
@@ -63,6 +66,7 @@ Each `[[plan]]` lists:
  * `string =` For http/https, a string we expect to find in the result.
  * `regex =` For http/https, a regular expression we expect to match in the result.
  * `timeout =` An optional timeout for the test in seconds. Default is 3 seconds.
+ * `tags =` An optional set of tags for the test. Used for when you want to only run a subset of tests with the `-tags` flag
 
 The test plan is run once for each item in the ips list, or more if macros
 are in effect.
@@ -154,6 +158,7 @@ INT (e.g. "16INT") to indicate a slightly diffenent list.
 	  ips = ["16", "8.7.6.5"]
 	  text = "API for example.com"
 	  regex = "some regex"
+	  tags = ["apis","example.com"]
 	
 	[[plan]]
 	  label = "redirect"
@@ -161,6 +166,7 @@ INT (e.g. "16INT") to indicate a slightly diffenent list.
 	  # This will generate the DNS A/AAAA records, 10.0.1.20, 10.0.2.20, 87.65.43.20, 87.65.43.84:
 	  ips = ["*", "20INT"]
 	  code = 301
+	  tags = ["redirect","example.com"]
 	
 	[[plan]]
 	  label = "mail"

--- a/cmd/httpunit/doc.go
+++ b/cmd/httpunit/doc.go
@@ -26,6 +26,9 @@ The flags are:
 		no RFC1918 addresses
 	-timeout="3s"
 		connection timeout
+	-tags=""
+	    if specified, only runs plans that are tagged with one of the
+		tags specified
 	-header="X-Request-Guid"
 		in more verbose mode, print this HTTP header
 	-v

--- a/cmd/httpunit/main.go
+++ b/cmd/httpunit/main.go
@@ -31,6 +31,7 @@ var (
 	header   = flag.String("header", "X-Request-Guid", "an HTTP to header to print in verbose mode")
 	timeout  = flag.Duration("timeout", httpunit.Timeout, "connection timeout")
 	ipMap    = flag.String("ipmap", "", `override or set one entry if the IPs table, in "key=value" format, where value is a JSON array of strings; for example: -ipmap='BASEIP=["10.2.3.", "1.4.5."]'`)
+	tags     = flag.String("tags", "", "if specified, only run plans that are tagged with these tags. Use comma seperated to include mutiple tags, e.g. \"normal,extended\"")
 )
 
 func printNames(x []pkix.AttributeTypeAndValue) []string {
@@ -155,7 +156,11 @@ func doMain() int {
 	if len(plans.Plans) == 0 {
 		log.Fatalf("no tests specified")
 	}
-	rch, count, err := plans.Test(*filter, *no10)
+	var tagFilter []string
+	if *tags != "" {
+		tagFilter = strings.Split(*tags, ",")
+	}
+	rch, count, err := plans.Test(*filter, *no10, tagFilter)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Adds tagging functionality, so you can specify HTTPUnit to only run plans that contain specific tags.

You can assign multiple tags to a test plan, and you can specify multiple plans to execute when running HTTPUnit.